### PR TITLE
Fix viewmodel package names

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/boxingapp/data/api/RetrofitInstance.kt
@@ -1,3 +1,4 @@
+package com.example.boxingapp.data.api
 import com.example.boxingapp.data.api.BoxingApiService
 import com.example.boxingapp.data.remote.DivisionApiService
 import okhttp3.OkHttpClient

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/DivisionScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/DivisionScreen.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.boxingapp.data.database.AppDatabase
-import com.example.boxingapp.ui.viewmodel.DivisionViewModel
-import com.example.boxingapp.ui.viewmodel.DivisionViewModelFactory
+import com.example.boxingapp.presentation.viewmodel.DivisionViewModel
+import com.example.boxingapp.presentation.viewmodel.DivisionViewModelFactory
 
 @Composable
 fun DivisionScreen() {

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/FavoritesScreen.kt
@@ -21,7 +21,7 @@ fun FavoritesScreen(
     val context = androidx.compose.ui.platform.LocalContext.current
     val db = com.example.boxingapp.data.database.AppDatabase.getInstance(context)
     val viewModel: FighterViewModel = androidx.lifecycle.viewmodel.compose.viewModel(
-        factory = com.example.boxingapp.ui.viewmodel.FighterViewModelFactory(
+        factory = com.example.boxingapp.presentation.viewmodel.FighterViewModelFactory(
             com.example.boxingapp.data.repository.FighterRepository(
                 apiService = RetrofitInstance.api,
                 fighterDao = db.fighterDao(),

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/FighterScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/FighterScreen.kt
@@ -45,15 +45,15 @@ import com.example.boxingapp.data.model.Division
 import com.example.boxingapp.data.repository.DivisionRepository
 import com.example.boxingapp.presentation.screens.NavRoutes
 import com.example.boxingapp.presentation.viewmodel.FighterViewModel
-import com.example.boxingapp.ui.viewmodel.DivisionViewModel
-import com.example.boxingapp.ui.viewmodel.DivisionViewModelFactory
+import com.example.boxingapp.presentation.viewmodel.DivisionViewModel
+import com.example.boxingapp.presentation.viewmodel.DivisionViewModelFactory
 import com.google.gson.Gson
 import java.net.URLEncoder
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.platform.LocalContext
 import com.example.boxingapp.data.database.AppDatabase
 import com.example.boxingapp.data.repository.FighterRepository
-import com.example.boxingapp.ui.viewmodel.FighterViewModelFactory
+import com.example.boxingapp.presentation.viewmodel.FighterViewModelFactory
 
 
 @Composable

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/DivisionViewModel.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/DivisionViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.boxingapp.ui.viewmodel
+package com.example.boxingapp.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/DivisionViewModelFactory.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/DivisionViewModelFactory.kt
@@ -1,4 +1,4 @@
-package com.example.boxingapp.ui.viewmodel
+package com.example.boxingapp.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/FighterViewModelFactory.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/FighterViewModelFactory.kt
@@ -1,4 +1,4 @@
-package com.example.boxingapp.ui.viewmodel
+package com.example.boxingapp.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider


### PR DESCRIPTION
## Summary
- declare package for `RetrofitInstance` so it lives under `data.api`
- fix inconsistent package names for viewmodel classes

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef8e812908332a74886e4422b5bde