### PR TITLE
Fix offline division caching with SQL joins

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/dao/FighterDao.kt
+++ b/app/src/main/java/com/example/boxingapp/data/dao/FighterDao.kt
@@ -2,6 +2,7 @@ package com.example.boxingapp.data.dao
 
 import androidx.room.*
 import com.example.boxingapp.data.entity.FighterEntity
+import com.example.boxingapp.data.entity.FighterWithDivision
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -25,6 +26,17 @@ interface FighterDao {
     @Query("SELECT * FROM fighters WHERE isFavorite = 1")
     suspend fun getFavorites(): List<FighterEntity>
 
+    @Query(
+        """
+        SELECT f.*, d.id AS division_id, d.name AS division_name,
+               d.weightKg AS division_weightKg, d.weightLb AS division_weightLb
+        FROM fighters f
+        LEFT JOIN divisions d ON f.divisionId = d.id
+        WHERE f.isFavorite = 1
+        """
+    )
+    suspend fun getFavoritesWithDivision(): List<FighterWithDivision>
+
 
     @Query("UPDATE fighters SET isFavorite = :isFavorite WHERE id = :fighterId")
     suspend fun updateFavoriteStatus(fighterId: String, isFavorite: Boolean)
@@ -40,8 +52,31 @@ interface FighterDao {
     """)
     suspend fun searchFighters(name: String?, divisionId: String?): List<FighterEntity>
 
+    @Query(
+        """
+        SELECT f.*, d.id AS division_id, d.name AS division_name,
+               d.weightKg AS division_weightKg, d.weightLb AS division_weightLb
+        FROM fighters f
+        LEFT JOIN divisions d ON f.divisionId = d.id
+        WHERE (:name IS NULL OR f.name LIKE '%' || :name || '%')
+          AND (:divisionId IS NULL OR f.divisionId = :divisionId)
+        """
+    )
+    suspend fun searchFightersWithDivision(name: String?, divisionId: String?): List<FighterWithDivision>
+
     @Query("SELECT * FROM fighters WHERE isFavorite = 1")
     fun getFavoritesFlow(): Flow<List<FighterEntity>>
+
+    @Query(
+        """
+        SELECT f.*, d.id AS division_id, d.name AS division_name,
+               d.weightKg AS division_weightKg, d.weightLb AS division_weightLb
+        FROM fighters f
+        LEFT JOIN divisions d ON f.divisionId = d.id
+        WHERE f.isFavorite = 1
+        """
+    )
+    fun getFavoritesFlowWithDivision(): Flow<List<FighterWithDivision>>
 
 
 }

--- a/app/src/main/java/com/example/boxingapp/data/entity/FighterWithDivision.kt
+++ b/app/src/main/java/com/example/boxingapp/data/entity/FighterWithDivision.kt
@@ -1,0 +1,19 @@
+package com.example.boxingapp.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+
+/**
+ * Represents a Fighter together with its Division from a JOIN query.
+ */
+data class FighterWithDivision(
+    @Embedded val fighter: FighterEntity,
+    @Embedded(prefix = "division_") val division: DivisionFields?,
+)
+
+data class DivisionFields(
+    @ColumnInfo(name = "division_id") val id: String?,
+    @ColumnInfo(name = "division_name") val name: String?,
+    @ColumnInfo(name = "division_weightKg") val weightKg: Double?,
+    @ColumnInfo(name = "division_weightLb") val weightLb: Double?,
+)

--- a/app/src/main/java/com/example/boxingapp/data/mapper/FighterMapper.kt
+++ b/app/src/main/java/com/example/boxingapp/data/mapper/FighterMapper.kt
@@ -1,6 +1,7 @@
 package com.example.boxingapp.data.mapper
 
 import com.example.boxingapp.data.entity.FighterEntity
+import com.example.boxingapp.data.entity.FighterWithDivision
 import com.example.boxingapp.data.model.Division
 import com.example.boxingapp.data.model.Fighter
 import com.example.boxingapp.data.model.Stats
@@ -39,6 +40,38 @@ object FighterMapper {
                 weight_kg = 0.0,
                 weight_lb = 0.0
             ),
+            stats = Stats(
+                wins = entity.wins,
+                losses = entity.losses,
+                draws = entity.draws,
+                total_bouts = entity.totalBouts
+            )
+        )
+    }
+
+    fun toModel(fighterWithDivision: FighterWithDivision): Fighter {
+        val entity = fighterWithDivision.fighter
+        val division = fighterWithDivision.division?.let {
+            Division(
+                id = it.id,
+                name = it.name,
+                weight_kg = it.weightKg,
+                weight_lb = it.weightLb
+            )
+        } ?: Division(
+            id = entity.divisionId,
+            name = "Nepoznata divizija",
+            weight_kg = 0.0,
+            weight_lb = 0.0
+        )
+
+        return Fighter(
+            id = entity.id,
+            name = entity.name,
+            isFavorite = entity.isFavorite,
+            nationality = entity.nationality,
+            gender = entity.gender ?: "Nepoznat",
+            division = division,
             stats = Stats(
                 wins = entity.wins,
                 losses = entity.losses,

--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -3,13 +3,8 @@ package com.example.boxingapp.data.repository
 import com.example.boxingapp.data.api.BoxingApiService
 import com.example.boxingapp.data.dao.DivisionDao
 import com.example.boxingapp.data.dao.FighterDao
-import com.example.boxingapp.data.entity.FighterEntity
 import com.example.boxingapp.data.mapper.FighterMapper
-import com.example.boxingapp.data.mapper.FighterMapper.toEntity
-import com.example.boxingapp.data.mapper.FighterMapper.toModel
 import com.example.boxingapp.data.mapper.toEntity
-import com.example.boxingapp.data.mapper.toModel
-import com.example.boxingapp.data.model.Division
 import com.example.boxingapp.data.model.Fighter
 import com.example.boxingapp.util.sanitizeFighter
 import kotlinx.coroutines.Dispatchers
@@ -67,7 +62,8 @@ class FighterRepository(
 
     private suspend fun getCachedFighters(name: String, divisionId: String?): List<Fighter> {
         return withContext(Dispatchers.IO) {
-            fighterDao.searchFighters(name, divisionId).map { toModel(it) }
+            fighterDao.searchFightersWithDivision(name, divisionId)
+                .map { FighterMapper.toModel(it) }
         }
     }
 
@@ -76,13 +72,13 @@ class FighterRepository(
     }
 
     suspend fun getFavorites(): List<Fighter> {
-        return fighterDao.getFavorites().map { toModel(it) }
+        return fighterDao.getFavoritesWithDivision().map { FighterMapper.toModel(it) }
     }
 
 
     fun getFavoritesFlow(): Flow<List<Fighter>> =
-        fighterDao.getFavoritesFlow().map { entityList ->
-            entityList.map { entity -> toModel(entity) }
+        fighterDao.getFavoritesFlowWithDivision().map { entityList ->
+            entityList.map { entity -> FighterMapper.toModel(entity) }
         }
 
 


### PR DESCRIPTION
## Summary
- replace `@Relation` with explicit SQL joins for fighter/division queries
- map joined columns to `Division` model

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f035033748332b55ec1d4cc9e94f9