### PR TITLE
Remove JOIN-based DAO

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
     id("org.jetbrains.kotlin.kapt")
 }
 
-apply(plugin = "kotlin-kapt")
-
 android {
     namespace = "com.example.boxingapp"
     compileSdk = 35

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,6 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version = "2.6.1" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 
 


### PR DESCRIPTION
## Summary
- drop FighterWithDivision helper and JOIN queries
- revert FighterDao and repository to simpler fighter entity
- keep kapt version aligned with Kotlin

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f035033748332b55ec1d4cc9e94f9