### PR TITLE
Fix online search with Retrofit query handling

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -33,8 +33,9 @@ class FighterRepository(
 
     suspend fun getFighters(name: String, divisionId: String?): List<Fighter> {
         return try {
-            val encodedName = java.net.URLEncoder.encode(name, "UTF-8")
-            val response = apiService.getFighters(encodedName)
+            // Retrofit handles query parameter encoding, so pass the raw
+            // string to avoid double encoding which breaks search results
+            val response = apiService.getFighters(name)
 
             if (response.isSuccessful) {
                 val apiFighters = response.body() ?: emptyList()


### PR DESCRIPTION
## Summary
- avoid double URL encoding in `FighterRepository` so online queries return results

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850224b91c483329a2811852b432952