### PR TITLE
Fix online fighter search

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/api/BoxingApiService.kt
+++ b/app/src/main/java/com/example/boxingapp/data/api/BoxingApiService.kt
@@ -15,4 +15,16 @@ interface BoxingApiService {
         @Query("page_size") size: Int = 50
     ): Response<List<Fighter>>
 
+    /**
+     * Some API endpoints provide a dedicated search path for fighter lookup
+     * by name.  When available, this returns a more precise result set than
+     * the generic [getFighters] call.
+     */
+    @GET("v1/fighters/search")
+    suspend fun searchFighters(
+        @Query("name") name: String,
+        @Query("page_num") page: Int = 1,
+        @Query("page_size") size: Int = 50
+    ): Response<List<Fighter>>
+
 }

--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -33,8 +33,13 @@ class FighterRepository(
 
     suspend fun getFighters(name: String, divisionId: String?): List<Fighter> {
         return try {
-            val encodedName = java.net.URLEncoder.encode(name, "UTF-8")
-            val response = apiService.getFighters(encodedName)
+            // Use the dedicated search endpoint when a query is provided for
+            // more accurate results. Retrofit handles encoding of parameters.
+            val response = if (name.isNotBlank()) {
+                apiService.searchFighters(name)
+            } else {
+                apiService.getFighters(name)
+            }
 
             if (response.isSuccessful) {
                 val apiFighters = response.body() ?: emptyList()


### PR DESCRIPTION
## Summary
- add new `searchFighters` endpoint to `BoxingApiService`
- use search endpoint in `FighterRepository` when query provided

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850224b91c483329a2811852b432952