### PR TITLE
Fix fighter search API call

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/dao/DivisionDao.kt
+++ b/app/src/main/java/com/example/boxingapp/data/dao/DivisionDao.kt
@@ -3,6 +3,7 @@ package com.example.boxingapp.data.dao
 import androidx.room.*
 import com.example.boxingapp.data.entity.DivisionEntity
 import kotlinx.coroutines.flow.Flow
+import kotlin.jvm.JvmSuppressWildcards
 
 @Dao
 interface DivisionDao {
@@ -23,6 +24,7 @@ interface DivisionDao {
     suspend fun getAllIds(): List<String>
 
     @Query("SELECT * FROM divisions WHERE id IN (:ids)")
+    @JvmSuppressWildcards
     suspend fun getByIds(ids: List<String>): List<DivisionEntity>
 
 }

--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -33,8 +33,9 @@ class FighterRepository(
 
     suspend fun getFighters(name: String, divisionId: String?): List<Fighter> {
         return try {
-            val encodedName = java.net.URLEncoder.encode(name, "UTF-8")
-            val response = apiService.getFighters(encodedName)
+            // Query the fighters endpoint directly. Retrofit handles encoding of
+            // parameters so we simply pass the search text as-is.
+            val response = apiService.getFighters(name)
 
             if (response.isSuccessful) {
                 val apiFighters = response.body() ?: emptyList()


### PR DESCRIPTION
## Summary
- remove unused `searchFighters` endpoint from `BoxingApiService`
- query `getFighters` directly in repository

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850224b91c483329a2811852b432952