### PR TITLE
Fix fighter search with dedicated endpoint

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/api/BoxingApiService.kt
+++ b/app/src/main/java/com/example/boxingapp/data/api/BoxingApiService.kt
@@ -15,4 +15,16 @@ interface BoxingApiService {
         @Query("page_size") size: Int = 50
     ): Response<List<Fighter>>
 
+    /**
+     * Endpoint for performing an exact fighter search. The API returns a
+     * 400 error when no matching fighter is found, so the repository handles
+     * this case and falls back to cached data.
+     */
+    @GET("v1/fighters/search")
+    suspend fun searchFighters(
+        @Query("name") name: String,
+        @Query("page_num") page: Int = 1,
+        @Query("page_size") size: Int = 50
+    ): Response<List<Fighter>>
+
 }

--- a/app/src/main/java/com/example/boxingapp/data/dao/DivisionDao.kt
+++ b/app/src/main/java/com/example/boxingapp/data/dao/DivisionDao.kt
@@ -3,6 +3,7 @@ package com.example.boxingapp.data.dao
 import androidx.room.*
 import com.example.boxingapp.data.entity.DivisionEntity
 import kotlinx.coroutines.flow.Flow
+import kotlin.jvm.JvmSuppressWildcards
 
 @Dao
 interface DivisionDao {
@@ -23,6 +24,7 @@ interface DivisionDao {
     suspend fun getAllIds(): List<String>
 
     @Query("SELECT * FROM divisions WHERE id IN (:ids)")
+    @JvmSuppressWildcards
     suspend fun getByIds(ids: List<String>): List<DivisionEntity>
 
 }

--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -33,8 +33,12 @@ class FighterRepository(
 
     suspend fun getFighters(name: String, divisionId: String?): List<Fighter> {
         return try {
-            val encodedName = java.net.URLEncoder.encode(name, "UTF-8")
-            val response = apiService.getFighters(encodedName)
+            // Use the dedicated search endpoint when a query is provided.
+            val response = if (name.isNotBlank()) {
+                apiService.searchFighters(name)
+            } else {
+                apiService.getFighters(name)
+            }
 
             if (response.isSuccessful) {
                 val apiFighters = response.body() ?: emptyList()


### PR DESCRIPTION
## Summary
- reintroduce `searchFighters` call in `BoxingApiService`
- call this search endpoint from `FighterRepository` when a query is provided