### PR TITLE
Fix search by reverting endpoint and adding logging

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/api/BoxingApiService.kt
+++ b/app/src/main/java/com/example/boxingapp/data/api/BoxingApiService.kt
@@ -14,5 +14,4 @@ interface BoxingApiService {
         @Query("page_num") page: Int = 1,
         @Query("page_size") size: Int = 50
     ): Response<List<Fighter>>
-
 }

--- a/app/src/main/java/com/example/boxingapp/data/dao/DivisionDao.kt
+++ b/app/src/main/java/com/example/boxingapp/data/dao/DivisionDao.kt
@@ -3,6 +3,7 @@ package com.example.boxingapp.data.dao
 import androidx.room.*
 import com.example.boxingapp.data.entity.DivisionEntity
 import kotlinx.coroutines.flow.Flow
+import kotlin.jvm.JvmSuppressWildcards
 
 @Dao
 interface DivisionDao {
@@ -23,6 +24,7 @@ interface DivisionDao {
     suspend fun getAllIds(): List<String>
 
     @Query("SELECT * FROM divisions WHERE id IN (:ids)")
+    @JvmSuppressWildcards
     suspend fun getByIds(ids: List<String>): List<DivisionEntity>
 
 }

--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -1,5 +1,6 @@
 package com.example.boxingapp.data.repository
 
+import android.util.Log
 import com.example.boxingapp.data.api.BoxingApiService
 import com.example.boxingapp.data.dao.DivisionDao
 import com.example.boxingapp.data.dao.FighterDao
@@ -33,8 +34,14 @@ class FighterRepository(
 
     suspend fun getFighters(name: String, divisionId: String?): List<Fighter> {
         return try {
-            val encodedName = java.net.URLEncoder.encode(name, "UTF-8")
-            val response = apiService.getFighters(encodedName)
+            android.util.Log.d("FighterRepo", "getFighters query=$name division=$divisionId")
+
+            // The API provides a single endpoint for listing fighters with an
+            // optional name query. Retrofit handles URL encoding so we pass the
+            // raw string directly.
+            val response = apiService.getFighters(name)
+
+            android.util.Log.d("FighterRepo", "API response code=${response.code()}")
 
             if (response.isSuccessful) {
                 val apiFighters = response.body() ?: emptyList()
@@ -58,11 +65,14 @@ class FighterRepository(
 
                 fightersToSave
             } else {
-                println("API ERROR ${response.code()} ${response.errorBody()?.string()}")
+                android.util.Log.d(
+                    "FighterRepo",
+                    "API error code=${response.code()} body=${response.errorBody()?.string()}"
+                )
                 getCachedFighters(name, divisionId)
             }
         } catch (e: Exception) {
-            println("❌ Network greška: ${e.message}")
+            android.util.Log.e("FighterRepo", "Network error: ${e.message}", e)
             getCachedFighters(name, divisionId)
         }
     }


### PR DESCRIPTION
## Summary
- rely on `getFighters` endpoint for searches instead of the unused `/search` call
- log search queries and API responses in `FighterRepository`

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850224b91c483329a2811852b432952