### PR TITLE
Handle API errors when fighter search response is empty

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -43,8 +43,9 @@ class FighterRepository(
 
             android.util.Log.d("FighterRepo", "API response code=${response.code()}")
 
-            if (response.isSuccessful) {
-                val apiFighters = response.body() ?: emptyList()
+            val body = response.body()
+            if (response.isSuccessful && body != null) {
+                val apiFighters = body
                 val fighters = apiFighters.map { sanitizeFighter(it) }
 
                 val favoriteIds = fighterDao.getFavorites().map { it.id }


### PR DESCRIPTION
## Summary
- improve `getFighters` to treat a null body as an error

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508e31612c833284942da548db00a4