### PR TITLE
Add local login and register

### DIFF
--- a/app/src/main/java/com/example/boxingapp/MainActivity.kt
+++ b/app/src/main/java/com/example/boxingapp/MainActivity.kt
@@ -20,7 +20,10 @@ import com.example.boxingapp.presentation.screens.NavRoutes
 import com.example.boxingapp.data.model.Fighter
 import com.example.boxingapp.presentation.screens.FavoritesScreen
 import com.example.boxingapp.presentation.screens.HomeScreen
+import com.example.boxingapp.presentation.screens.LoginScreen
+import com.example.boxingapp.presentation.screens.RegisterScreen
 import com.example.boxingapp.data.preferences.ThemePreferenceRepository
+import com.example.boxingapp.data.preferences.UserPreferenceRepository
 import com.google.gson.Gson
 import java.net.URLDecoder
 
@@ -30,9 +33,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val themeRepo = ThemePreferenceRepository(applicationContext)
+        val userPrefs = UserPreferenceRepository(applicationContext)
 
         setContent {
             val darkThemeEnabled by themeRepo.darkThemeFlow.collectAsState(initial = false)
+            val loggedInUser by userPrefs.loggedInUserFlow.collectAsState(initial = null)
             val scope = rememberCoroutineScope()
 
             BoxingAppTheme(darkTheme = darkThemeEnabled) {
@@ -40,8 +45,14 @@ class MainActivity : ComponentActivity() {
                     val navController = rememberNavController()
                     NavHost(
                         navController = navController,
-                        startDestination = NavRoutes.Home
+                        startDestination = if (loggedInUser == null) NavRoutes.Login else NavRoutes.Home
                     ) {
+                        composable(NavRoutes.Login) {
+                            LoginScreen(navController)
+                        }
+                        composable(NavRoutes.Register) {
+                            RegisterScreen(navController)
+                        }
                         composable(NavRoutes.Home) {
                             HomeScreen(
                                 navController = navController,

--- a/app/src/main/java/com/example/boxingapp/data/dao/UserDao.kt
+++ b/app/src/main/java/com/example/boxingapp/data/dao/UserDao.kt
@@ -1,0 +1,16 @@
+package com.example.boxingapp.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.boxingapp.data.entity.UserEntity
+
+@Dao
+interface UserDao {
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(user: UserEntity)
+
+    @Query("SELECT * FROM users WHERE username = :username")
+    suspend fun getByUsername(username: String): UserEntity?
+}

--- a/app/src/main/java/com/example/boxingapp/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/boxingapp/data/database/AppDatabase.kt
@@ -6,18 +6,21 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.example.boxingapp.data.dao.DivisionDao
 import com.example.boxingapp.data.dao.FighterDao
+import com.example.boxingapp.data.dao.UserDao
 import com.example.boxingapp.data.entity.DivisionEntity
 import com.example.boxingapp.data.entity.FighterEntity
+import com.example.boxingapp.data.entity.UserEntity
 
 @Database(
-    entities = [FighterEntity::class, DivisionEntity::class],
-    version = 3,
+    entities = [FighterEntity::class, DivisionEntity::class, UserEntity::class],
+    version = 4,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun fighterDao(): FighterDao
     abstract fun divisionDao(): DivisionDao
+    abstract fun userDao(): UserDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/example/boxingapp/data/entity/UserEntity.kt
+++ b/app/src/main/java/com/example/boxingapp/data/entity/UserEntity.kt
@@ -1,0 +1,10 @@
+package com.example.boxingapp.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "users")
+data class UserEntity(
+    @PrimaryKey val username: String,
+    val password: String
+)

--- a/app/src/main/java/com/example/boxingapp/data/preferences/UserPreferenceRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/preferences/UserPreferenceRepository.kt
@@ -1,0 +1,29 @@
+package com.example.boxingapp.data.preferences
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.userDataStore by preferencesDataStore(name = "user_prefs")
+
+class UserPreferenceRepository(private val context: Context) {
+    companion object {
+        private val LOGGED_IN_USER_KEY = stringPreferencesKey("logged_in_user")
+    }
+
+    val loggedInUserFlow: Flow<String?> = context.userDataStore.data
+        .map { prefs -> prefs[LOGGED_IN_USER_KEY] }
+
+    suspend fun setLoggedInUser(username: String?) {
+        context.userDataStore.edit { prefs ->
+            if (username == null) {
+                prefs.remove(LOGGED_IN_USER_KEY)
+            } else {
+                prefs[LOGGED_IN_USER_KEY] = username
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/boxingapp/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/UserRepository.kt
@@ -1,0 +1,21 @@
+package com.example.boxingapp.data.repository
+
+import com.example.boxingapp.data.dao.UserDao
+import com.example.boxingapp.data.entity.UserEntity
+
+class UserRepository(private val userDao: UserDao) {
+    suspend fun register(username: String, password: String): Boolean {
+        val existing = userDao.getByUsername(username)
+        return if (existing == null) {
+            userDao.insert(UserEntity(username, password))
+            true
+        } else {
+            false
+        }
+    }
+
+    suspend fun login(username: String, password: String): Boolean {
+        val user = userDao.getByUsername(username)
+        return user?.password == password
+    }
+}

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/HomeScreen.kt
@@ -6,11 +6,19 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.example.boxingapp.data.database.AppDatabase
+import com.example.boxingapp.data.preferences.UserPreferenceRepository
+import com.example.boxingapp.data.repository.UserRepository
+import com.example.boxingapp.presentation.viewmodel.AuthViewModel
+import com.example.boxingapp.presentation.viewmodel.AuthViewModelFactory
 
 @Composable
 fun HomeScreen(
@@ -18,6 +26,14 @@ fun HomeScreen(
     isDarkTheme: Boolean,
     onToggleTheme: (Boolean) -> Unit
 ) {
+    val context = LocalContext.current
+    val db = remember { AppDatabase.getInstance(context) }
+    val authViewModel: AuthViewModel = viewModel(
+        factory = AuthViewModelFactory(
+            UserRepository(db.userDao()),
+            UserPreferenceRepository(context)
+        )
+    )
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -73,6 +89,20 @@ fun HomeScreen(
                 checked = isDarkTheme,
                 onCheckedChange = { onToggleTheme(it) }
             )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedButton(
+            onClick = {
+                authViewModel.logout()
+                navController.navigate(NavRoutes.Login) {
+                    popUpTo(NavRoutes.Home) { inclusive = true }
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Odjava")
         }
     }
 }

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/LoginScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/LoginScreen.kt
@@ -1,0 +1,71 @@
+package com.example.boxingapp.presentation.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.boxingapp.data.database.AppDatabase
+import com.example.boxingapp.data.preferences.UserPreferenceRepository
+import com.example.boxingapp.data.repository.UserRepository
+import com.example.boxingapp.presentation.viewmodel.AuthViewModel
+import com.example.boxingapp.presentation.viewmodel.AuthViewModelFactory
+
+@Composable
+fun LoginScreen(navController: NavController) {
+    val context = LocalContext.current
+    val db = remember { AppDatabase.getInstance(context) }
+    val viewModel: AuthViewModel = viewModel(
+        factory = AuthViewModelFactory(
+            UserRepository(db.userDao()),
+            UserPreferenceRepository(context)
+        )
+    )
+
+    val loggedIn by viewModel.loggedInUser.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    LaunchedEffect(loggedIn) {
+        if (loggedIn != null) {
+            navController.navigate(NavRoutes.Home) {
+                popUpTo(NavRoutes.Login) { inclusive = true }
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        OutlinedTextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Korisničko ime") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Lozinka") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { viewModel.login(username, password) }, modifier = Modifier.fillMaxWidth()) {
+            Text("Prijava")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        TextButton(onClick = { navController.navigate(NavRoutes.Register) }) {
+            Text("Registracija")
+        }
+    }
+}

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/NavRoutes.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/NavRoutes.kt
@@ -1,6 +1,8 @@
 package com.example.boxingapp.presentation.screens
 
 object NavRoutes {
+    const val Login = "login"
+    const val Register = "register"
     const val Home = "home"
     const val FighterList = "fighters"
     const val FighterDetail = "fighter_detail"

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/RegisterScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/RegisterScreen.kt
@@ -1,0 +1,67 @@
+package com.example.boxingapp.presentation.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import com.example.boxingapp.data.database.AppDatabase
+import com.example.boxingapp.data.preferences.UserPreferenceRepository
+import com.example.boxingapp.data.repository.UserRepository
+import com.example.boxingapp.presentation.viewmodel.AuthViewModel
+import com.example.boxingapp.presentation.viewmodel.AuthViewModelFactory
+
+@Composable
+fun RegisterScreen(navController: NavController) {
+    val context = LocalContext.current
+    val db = remember { AppDatabase.getInstance(context) }
+    val viewModel: AuthViewModel = viewModel(
+        factory = AuthViewModelFactory(
+            UserRepository(db.userDao()),
+            UserPreferenceRepository(context)
+        )
+    )
+
+    val loggedIn by viewModel.loggedInUser.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    LaunchedEffect(loggedIn) {
+        if (loggedIn != null) {
+            navController.navigate(NavRoutes.Home) {
+                popUpTo(NavRoutes.Register) { inclusive = true }
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+        OutlinedTextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Korisničko ime") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Lozinka") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { viewModel.register(username, password) }, modifier = Modifier.fillMaxWidth()) {
+            Text("Registriraj se")
+        }
+    }
+}

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/AuthViewModel.kt
@@ -1,0 +1,54 @@
+package com.example.boxingapp.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.boxingapp.data.preferences.UserPreferenceRepository
+import com.example.boxingapp.data.repository.UserRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class AuthViewModel(
+    private val userRepository: UserRepository,
+    private val prefs: UserPreferenceRepository
+) : ViewModel() {
+
+    val loggedInUser: StateFlow<String?> = prefs.loggedInUserFlow.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        null
+    )
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
+
+    fun login(username: String, password: String) {
+        viewModelScope.launch {
+            val success = userRepository.login(username, password)
+            if (success) {
+                prefs.setLoggedInUser(username)
+                _error.value = null
+            } else {
+                _error.value = "Neispravni podaci"
+            }
+        }
+    }
+
+    fun register(username: String, password: String) {
+        viewModelScope.launch {
+            val success = userRepository.register(username, password)
+            if (success) {
+                prefs.setLoggedInUser(username)
+                _error.value = null
+            } else {
+                _error.value = "Korisnik već postoji"
+            }
+        }
+    }
+
+    fun logout() {
+        viewModelScope.launch { prefs.setLoggedInUser(null) }
+    }
+}

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/AuthViewModelFactory.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/AuthViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.example.boxingapp.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.boxingapp.data.preferences.UserPreferenceRepository
+import com.example.boxingapp.data.repository.UserRepository
+
+class AuthViewModelFactory(
+    private val userRepository: UserRepository,
+    private val prefs: UserPreferenceRepository
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AuthViewModel::class.java)) {
+            return AuthViewModel(userRepository, prefs) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Summary
- add user entity, DAO and repository for local credential storage
- add datastore-based user preference repository
- create AuthViewModel and factory
- implement simple Login and Register screens
- integrate authentication into navigation
- extend Room database
- require login before home screen
- add logout button on HomeScreen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685090866cac833298bc9dcad431bcb0