### PR TITLE
Implement offline search for fighters

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -32,7 +32,15 @@ class FighterRepository(
         } else base
     }
 
-    suspend fun getFighters(name: String, divisionId: String?): List<Fighter> {
+    suspend fun getFighters(
+        name: String,
+        divisionId: String?,
+        isConnected: Boolean = true
+    ): List<Fighter> {
+        if (!isConnected) {
+            return getCachedFighters(name, divisionId)
+        }
+
         return try {
             android.util.Log.d("FighterRepo", "getFighters query=$name division=$divisionId")
 

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/FavoritesScreen.kt
@@ -27,7 +27,8 @@ fun FavoritesScreen(
                 apiService = RetrofitInstance.api,
                 fighterDao = db.fighterDao(),
                 divisionDao = db.divisionDao()
-            )
+            ),
+            context
         )
     )
 

--- a/app/src/main/java/com/example/boxingapp/presentation/screens/FighterScreen.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/screens/FighterScreen.kt
@@ -147,7 +147,8 @@ fun FighterScreen(
                 apiService = RetrofitInstance.api,
                 fighterDao = db.fighterDao(),
                 divisionDao = db.divisionDao()
-            )
+            ),
+            context
         )
     )
 

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/FighterViewModel.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/FighterViewModel.kt
@@ -2,14 +2,16 @@ package com.example.boxingapp.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.boxingapp.data.database.AppDatabase
 import com.example.boxingapp.data.model.Fighter
 import com.example.boxingapp.data.repository.FighterRepository
+import com.example.boxingapp.util.isInternetAvailable
+import android.content.Context
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 class FighterViewModel(
-    private val repository: FighterRepository
+    private val repository: FighterRepository,
+    private val context: Context
 ) : ViewModel() {
 
     val favorites: StateFlow<List<Fighter>> = repository.getFavoritesFlow()
@@ -75,7 +77,8 @@ class FighterViewModel(
             try {
                 val fighters = repository.getFighters(
                     name = _query.value.trim(),
-                    divisionId = _selectedDivisionId.value
+                    divisionId = _selectedDivisionId.value,
+                    isConnected = isInternetAvailable(context)
                 )
                 _fighters.value = fighters
                 _error.value = null

--- a/app/src/main/java/com/example/boxingapp/presentation/viewmodel/FighterViewModelFactory.kt
+++ b/app/src/main/java/com/example/boxingapp/presentation/viewmodel/FighterViewModelFactory.kt
@@ -3,14 +3,16 @@ package com.example.boxingapp.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.example.boxingapp.data.repository.FighterRepository
+import android.content.Context
 import com.example.boxingapp.presentation.viewmodel.FighterViewModel
 
 class FighterViewModelFactory(
-    private val repository: FighterRepository
+    private val repository: FighterRepository,
+    private val context: Context
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(FighterViewModel::class.java)) {
-            return FighterViewModel(repository) as T
+            return FighterViewModel(repository, context.applicationContext) as T
         }
         throw IllegalArgumentException("Nepoznata klasa ViewModela")
     }

--- a/app/src/main/java/com/example/boxingapp/util/NetworkUtils.kt
+++ b/app/src/main/java/com/example/boxingapp/util/NetworkUtils.kt
@@ -1,0 +1,14 @@
+package com.example.boxingapp.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+fun isInternetAvailable(context: Context): Boolean {
+    val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
+            ?: return false
+    val network = connectivityManager.activeNetwork ?: return false
+    val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+}


### PR DESCRIPTION
## Summary
- add `NetworkUtils` helper to detect connectivity
- allow `FighterRepository.getFighters` to bypass API calls when offline
- update `FighterViewModel` to provide connectivity state to repository
- pass `Context` into `FighterViewModelFactory`
- update `FighterScreen` and `FavoritesScreen` to supply context
