### PR TITLE
Fix favorite fighters being cleared on network update

### DIFF
--- a/app/src/main/java/com/example/boxingapp/data/dao/FighterDao.kt
+++ b/app/src/main/java/com/example/boxingapp/data/dao/FighterDao.kt
@@ -4,6 +4,7 @@ import androidx.room.*
 import com.example.boxingapp.data.entity.FighterEntity
 import com.example.boxingapp.data.entity.FighterWithDivision
 import kotlinx.coroutines.flow.Flow
+import kotlin.jvm.JvmSuppressWildcards
 
 @Dao
 interface FighterDao {
@@ -43,6 +44,10 @@ interface FighterDao {
 
     @Query("DELETE FROM fighters")
     suspend fun clearAll()
+
+    @JvmSuppressWildcards
+    @Query("SELECT * FROM fighters WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<String>): List<FighterEntity>
 
 
     @Query("""

--- a/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
+++ b/app/src/main/java/com/example/boxingapp/data/repository/FighterRepository.kt
@@ -56,10 +56,12 @@ class FighterRepository(
                 val apiFighters = body
                 val fighters = apiFighters.map { sanitizeFighter(it) }
 
-                val favoriteIds = fighterDao.getFavorites().map { it.id }
+                val ids = fighters.mapNotNull { it.id }
+                val existing = fighterDao.getByIds(ids)
+                val existingFavorites = existing.filter { it.isFavorite }.map { it.id }
 
                 val fightersToSave = fighters.map { fighter ->
-                    fighter.copy(isFavorite = favoriteIds.contains(fighter.id))
+                    fighter.copy(isFavorite = existingFavorites.contains(fighter.id))
                 }
 
                 val divisionsToSave = fightersToSave


### PR DESCRIPTION
## Summary
- keep existing favorite status when inserting fighters from the API
- add DAO method for retrieving fighters by ID